### PR TITLE
Fix closing on right click bug

### DIFF
--- a/src_htmlPhone/src/components/List.vue
+++ b/src_htmlPhone/src/components/List.vue
@@ -9,15 +9,15 @@
           v-bind:key="elem[keyDispay]"
           v-bind:class="{ select: key === currentSelect}"
           @click.stop="selectItem(elem)"
-          @contextmenu.prevent="optionItem(elem)"
+          @contextmenu.prevent.stop="optionItem(elem)"
           >
             <div class="elem-pic" v-bind:style="stylePuce(elem)" @click.stop="selectItem(elem)">
               {{elem.letter || elem[keyDispay][0]}}
             </div>
-            <div @click.stop="selectItem(elem)" v-if="elem.puce !== undefined && elem.puce !== 0" class="elem-puce">{{elem.puce}}</div>
-            <div @click.stop="selectItem(elem)" v-if="elem.keyDesc === undefined || elem.keyDesc === ''" class="elem-title">{{elem[keyDispay]}}</div>
-            <div @click.stop="selectItem(elem)" v-if="elem.keyDesc !== undefined && elem.keyDesc !== ''" class="elem-title-has-desc">{{elem[keyDispay]}}</div>
-            <div @click.stop="selectItem(elem)" v-if="elem.keyDesc !== undefined && elem.keyDesc !== ''" class="elem-description">{{elem.keyDesc}}</div>
+            <div @click.stop="selectItem(elem)" @contextmenu.prevent.stop="optionItem(elem)" v-if="elem.puce !== undefined && elem.puce !== 0" class="elem-puce">{{elem.puce}}</div>
+            <div @click.stop="selectItem(elem)" @contextmenu.prevent.stop="optionItem(elem)" v-if="elem.keyDesc === undefined || elem.keyDesc === ''" class="elem-title">{{elem[keyDispay]}}</div>
+            <div @click.stop="selectItem(elem)" @contextmenu.prevent.stop="optionItem(elem)" v-if="elem.keyDesc !== undefined && elem.keyDesc !== ''" class="elem-title-has-desc">{{elem[keyDispay]}}</div>
+            <div @click.stop="selectItem(elem)" @contextmenu.prevent.stop="optionItem(elem)" v-if="elem.keyDesc !== undefined && elem.keyDesc !== ''" class="elem-description">{{elem.keyDesc}}</div>
         </div>
     </div>
   </div>

--- a/src_htmlPhone/src/components/messages/Messages.vue
+++ b/src_htmlPhone/src/components/messages/Messages.vue
@@ -9,8 +9,8 @@
     <textarea ref="copyTextarea" class="copyTextarea"/>
     
     
-    <div style="width: 326px; height: 678px; backgroundColor: white"  id='sms_list' @contextmenu.prevent="showOptions">
-        <div class="sms" v-bind:class="{ select: key === selectMessage}" v-for='(mess, key) in messagesList' v-bind:key="mess.id" @click.stop="onActionMessage(mess)"
+    <div style="width: 326px; height: 678px; backgroundColor: white"  id='sms_list' @contextmenu.prevent.stop="showOptions">
+        <div class="sms" v-bind:class="{ select: key === selectMessage}" v-for='(mess, key) in messagesList' v-bind:key="mess.id" @click.stop="onActionMessage(mess)" @contextmenu.prevent.stop="showOptions"
         >
           <div class="sms_message_time">
               <h6  v-bind:class="{ sms_me : mess.owner === 1}"  class="name_other_sms_me">{{displayContact}}</h6>


### PR DESCRIPTION
this bug does not happen 100% of the time, but does happen consistently for many of my players. 

if you are using the mouse and right click an item in the message list to get it's menu you'll close the phone instead of opening the menu. the same thing happens when right clicking to send location.

this commit fixes these issues.